### PR TITLE
Extended error handling with proper http responses

### DIFF
--- a/flask_jwtauthorization/__init__.py
+++ b/flask_jwtauthorization/__init__.py
@@ -51,9 +51,7 @@ def jwt_authorize(**auth_kwargs):
             kwargs.update(auth_kwargs)
             _check_authorization(user, callback, **kwargs)
             return fn(*args, **kwargs)
-
         return decorator
-
     return wrapper
 
 

--- a/flask_jwtauthorization/__init__.py
+++ b/flask_jwtauthorization/__init__.py
@@ -105,13 +105,13 @@ def _get_authorization_callback(auth_func, auth_cls, args):
 
     TODO complete this help when we have decided the options offered.
     """
-    if auth_func:
+    if auth_func is not None:
         if not callable(auth_func):
             abort(500, 'JWT Authorization: No valid authorization callback function provided')
         return auth_func
     else:
         method = 'auth_{0}'.format(request.method.lower())
-        if auth_cls:
+        if auth_cls is not None:
             instance = auth_cls()
         else:
             # If no method/class has been passed, maybe first argument is the instance of the same class

--- a/flask_jwtauthorization/__init__.py
+++ b/flask_jwtauthorization/__init__.py
@@ -137,17 +137,3 @@ def _check_authorization(user, auth_func, **kwargs):
     if user in auth_list:
         return
     abort(403, 'JWT Authorization: User is not authorized to access this endpoint')
-
-
-class JWTAuthorizationError(Exception):
-    def __init__(self, error, description, status_code=403, headers=None):
-        self.error = error
-        self.description = description
-        self.status_code = status_code
-        self.headers = headers
-
-    def __repr__(self):
-        return 'JWT Authorization Error: %s' % self.error
-
-    def __str__(self):
-        return '%s. %s' % (self.error, self.description)

--- a/flask_jwtauthorization/__init__.py
+++ b/flask_jwtauthorization/__init__.py
@@ -10,7 +10,7 @@
 from functools import wraps
 
 import jwt
-from flask import request, current_app, g
+from flask import request, current_app, g, abort
 
 
 def jwt_authorize(**auth_kwargs):
@@ -67,19 +67,19 @@ def _token_extractor():
     auth_bearer_prefix = current_app.config.get('JWTAUTH_BEARER_PREFIX', 'JWT')
     if not auth_header_value:
         return
-
     parts = auth_header_value.split()
-    if parts[0].lower() != auth_bearer_prefix.lower():
-        raise JWTAuthorizationError('Invalid JWT header', 'Unsupported authorization type')
-    elif len(parts) == 1:
-        raise JWTAuthorizationError('Invalid JWT header', 'Token missing')
-    elif len(parts) > 2:
-        raise JWTAuthorizationError('Invalid JWT header', 'Token contains spaces')
-
-    if parts[0] is None:
-        raise JWTAuthorizationError('Authorization required', 'Request does not contain an access token')
-
-    return parts[1]
+    try:
+        if parts[0].lower() != auth_bearer_prefix.lower():
+            raise JWTAuthorizationError('Invalid JWT header', 'Unsupported authorization type')
+        elif len(parts) == 1:
+            raise JWTAuthorizationError('Invalid JWT header', 'Token missing')
+        elif len(parts) > 2:
+            raise JWTAuthorizationError('Invalid JWT header', 'Token contains spaces')
+        if not parts[0]:
+            raise JWTAuthorizationError('Authorization required', 'Request does not contain an access token')
+        return parts[1]
+    except JWTAuthorizationError as e:
+        abort(400, e)
 
 
 def _user_decode(token):
@@ -91,15 +91,17 @@ def _user_decode(token):
     To specify where to retrieve user name, use JWTAUTH_USER_FIELD.
     """
     try:
-        secret = current_app.config.get('JWTAUTH_SECRET', current_app.config.get('SECRET_KEY'))
-        user_field = current_app.config.get('JWTAUTH_USER_FIELD', 'login')
-        user = jwt.decode(token, secret)[user_field]
-    except jwt.InvalidTokenError as e:
-        raise JWTAuthorizationError('Invalid JWT', str(e))
-    except KeyError:
-        raise JWTAuthorizationError('Invalid JWT', user_field + ' parameter does not exist')
-
-    return user
+        try:
+            secret = current_app.config.get('JWTAUTH_SECRET', current_app.config.get('SECRET_KEY'))
+            user_field = current_app.config.get('JWTAUTH_USER_FIELD', 'login')
+            user = jwt.decode(token, secret)[user_field]
+        except jwt.InvalidTokenError as e:
+            raise JWTAuthorizationError('Invalid JWT', str(e))
+        except KeyError:
+            raise JWTAuthorizationError('Invalid JWT', user_field + ' parameter does not exist')
+        return user
+    except JWTAuthorizationError as e:
+        abort(400, e)
 
 
 def _get_authorization_callback(auth_func, auth_cls, args):
@@ -108,25 +110,28 @@ def _get_authorization_callback(auth_func, auth_cls, args):
 
     TODO complete this help when we have decided the options offered.
     """
-    if auth_func != None:
-        if not callable(auth_func):
-            raise JWTAuthorizationError('JWT Authorization', 'No valid authorization callback function provided')
-        return auth_func
-    else:
-        method = 'auth_{0}'.format(request.method.lower())
-        if auth_cls != None:
-            instance = auth_cls()
-        else:
-            # If no method/class has been passed, maybe first argument is the instance of the same class
-            try:
-                instance = args[0]
-            except IndexError:
+    try:
+        if auth_func:
+            if not callable(auth_func):
                 raise JWTAuthorizationError('JWT Authorization', 'No valid authorization callback function provided')
-        try:
-            callback = getattr(instance, method)
-            return callback
-        except AttributeError:
-            raise JWTAuthorizationError('JWT Authorization', 'No valid authorization callback function provided')
+            return auth_func
+        else:
+            method = 'auth_{0}'.format(request.method.lower())
+            if auth_cls:
+                instance = auth_cls()
+            else:
+                # If no method/class has been passed, maybe first argument is the instance of the same class
+                try:
+                    instance = args[0]
+                except IndexError:
+                    raise JWTAuthorizationError('JWT Authorization', 'No valid authorization callback function provided')
+            try:
+                callback = getattr(instance, method)
+                return callback
+            except AttributeError:
+                raise JWTAuthorizationError('JWT Authorization', 'No valid authorization callback function provided')
+    except JWTAuthorizationError as e:
+        abort(500, e)
 
 
 def _check_authorization(user, auth_func, **kwargs):
@@ -135,12 +140,14 @@ def _check_authorization(user, auth_func, **kwargs):
     admin users so they are always authorized to use full API. This is defined as a list of users
     in configuration key JWTAUTH_API_ADMINS.
     """
-    auth_list = auth_func(**kwargs)
-    auth_list.extend(current_app.config.get('JWTAUTH_API_ADMINS', []))
-    if user in auth_list:
-        return
-    raise JWTAuthorizationError('JWT Authorization', 'User is not authorized to access this endpoint')
-
+    try:
+        auth_list = auth_func(**kwargs)
+        auth_list.extend(current_app.config.get('JWTAUTH_API_ADMINS', []))
+        if user in auth_list:
+            return
+        raise JWTAuthorizationError('JWT Authorization', 'User is not authorized to access this endpoint')
+    except JWTAuthorizationError as e:
+        abort(401, e)
 
 
 class JWTAuthorizationError(Exception):
@@ -150,10 +157,8 @@ class JWTAuthorizationError(Exception):
         self.status_code = status_code
         self.headers = headers
 
-
     def __repr__(self):
         return 'JWT Authorization Error: %s' % self.error
-
 
     def __str__(self):
         return '%s. %s' % (self.error, self.description)


### PR DESCRIPTION
hey Sergio :)

While making a request for instance as an unauthorized user exception is thrown already in the decorator, what makes it tricky to handle. A dirty workaround for that would be to create another decorator only for catching the JWTAuthorizationError and put it before the flask-jwtauthorization decorator. Instead of that I extended the library with appropriate http responses what makes it easier to use, as no additional actions are required from the library user.

Cheers,
Wojtek